### PR TITLE
global const declaration not allowed by julia 1.0.2 inside function

### DIFF
--- a/src/GtkExtensions.jl
+++ b/src/GtkExtensions.jl
@@ -428,8 +428,9 @@ function foreach(model::Gtk.GtkTreeModel, f::Function, data)
                 model,foreach_function,pointer_from_objref(data))
 end
 
+global default_css_provider = convert(Ptr{Gtk.GObject}, 0)
 function __init__()
-    global const default_css_provider = GtkCssProviderLeaf(
+    global default_css_provider = GtkCssProviderLeaf(
         ccall((:gtk_css_provider_get_default,libgtk),Ptr{Gtk.GObject},())
     )
 end


### PR DESCRIPTION
julia 1.0.2 is not allowing such declaration:

ERROR: LoadError: syntax: `global const` declaration not allowed inside function